### PR TITLE
Extended support for software I2C and additional hardware (ESP8266)

### DIFF
--- a/Adafruit_MPR121.cpp
+++ b/Adafruit_MPR121.cpp
@@ -24,6 +24,18 @@ boolean Adafruit_MPR121::begin(uint8_t i2caddr) {
     
   _i2caddr = i2caddr;
 
+  return initMPR121();
+}
+
+boolean Adafruit_MPR121::begin(uint8_t i2caddr, uint8_t sdaPin, uint8_t sclPin) {
+  Wire.begin(sdaPin, sclPin);
+    
+  _i2caddr = i2caddr;
+
+  return initMPR121();
+}
+
+boolean Adafruit_MPR121::initMPR121(){
   // soft reset
   writeRegister(MPR121_SOFTRESET, 0x63);
   delay(1);
@@ -66,7 +78,6 @@ boolean Adafruit_MPR121::begin(uint8_t i2caddr) {
 //  writeRegister(MPR121_LOWLIMIT, 50);
   // enable all electrodes
   writeRegister(MPR121_ECR, 0x8F);  // start with first 5 bits of baseline tracking
-
   return true;
 }
 

--- a/Adafruit_MPR121.h
+++ b/Adafruit_MPR121.h
@@ -75,6 +75,7 @@ class Adafruit_MPR121 {
   Adafruit_MPR121(void);
 
   boolean begin(uint8_t i2caddr = MPR121_I2CADDR_DEFAULT);
+  boolean begin(uint8_t i2caddr = MPR121_I2CADDR_DEFAULT, uint8_t sdaPin = SDA, uint8_t sclPin = SCL);
 
   uint16_t filteredData(uint8_t t);
   uint16_t  baselineData(uint8_t t);
@@ -89,6 +90,7 @@ class Adafruit_MPR121 {
 
  private:
   int8_t _i2caddr;
+  boolean initMPR121();
 };
 
 #endif // ADAFRUIT_MPR121_H

--- a/Adafruit_MPR121.h
+++ b/Adafruit_MPR121.h
@@ -75,7 +75,7 @@ class Adafruit_MPR121 {
   Adafruit_MPR121(void);
 
   boolean begin(uint8_t i2caddr = MPR121_I2CADDR_DEFAULT);
-  boolean begin(uint8_t i2caddr = MPR121_I2CADDR_DEFAULT, uint8_t sdaPin = SDA, uint8_t sclPin = SCL);
+  boolean begin(uint8_t i2caddr, uint8_t sdaPin, uint8_t sclPin);
 
   uint16_t filteredData(uint8_t t);
   uint16_t  baselineData(uint8_t t);
@@ -90,7 +90,7 @@ class Adafruit_MPR121 {
 
  private:
   int8_t _i2caddr;
-  boolean initMPR121();
+  boolean initMPR121(void);
 };
 
 #endif // ADAFRUIT_MPR121_H


### PR DESCRIPTION
Added additional constructor to specify sda/scl pins explicitly.
This change was needed to support easy software I2C on non arduino hardware such as ESP8266.

Tested on ESP8266.

- added additional constructor to specify SDA/SCL pins
- refactored hardware/chip initialization into separated init-method