### PR TITLE
Debounce / IRQ / GPIO-IN / GPIO-OUT

### DIFF
--- a/Adafruit_MPR121.cpp
+++ b/Adafruit_MPR121.cpp
@@ -241,7 +241,6 @@ boolean Adafruit_MPR121::getGPIOStatus(uint8_t channelID){
 */
 void Adafruit_MPR121::setGPIOEnabled(uint8_t channelID, boolean enable){
   if(_channels[channelID]._type == MPR121_SENSOR){
-    Serial.println("return -> SENSOR");
     return;
   }
   
@@ -332,10 +331,7 @@ uint16_t  Adafruit_MPR121::touched(void) {
   //if interrupt is used then return IRQ status
   if(_useIRQ){
     result = _interrupted ? 1 : 0;
-  }else{ 
-    //check global debounce
-    //TODO
-    
+  }else{     
     //else read status from MPR121 registers
     result = readRegister16(MPR121_TOUCHSTATUS_L) & 0x0FFF;
   }

--- a/Adafruit_MPR121.cpp
+++ b/Adafruit_MPR121.cpp
@@ -147,10 +147,8 @@ void Adafruit_MPR121::setThresholds(uint8_t touch, uint8_t release) {
   }
 }
 
-void Adafruit_MPR121::registerIRQ(uint8_t irqPin){
-  _irqPin = irqPin;
+void Adafruit_MPR121::useIRQ(){
   _useIRQ = true;
-  attachInterrupt(_irqPin,fireIRQ,RISING);
 }
 
 void Adafruit_MPR121::fireIRQ(){

--- a/Adafruit_MPR121.cpp
+++ b/Adafruit_MPR121.cpp
@@ -24,6 +24,18 @@ boolean Adafruit_MPR121::begin(uint8_t i2caddr) {
     
   _i2caddr = i2caddr;
 
+  return initMPR121();
+}
+
+boolean Adafruit_MPR121::begin(uint8_t i2caddr, uint8_t sdaPin, uint8_t sclPin) {
+  Wire.begin(sdaPin, sclPin);
+    
+  _i2caddr = i2caddr;
+
+  return initMPR121();
+}
+
+boolean Adafruit_MPR121::initMPR121(){
   // soft reset
   writeRegister(MPR121_SOFTRESET, 0x63);
   delay(1);
@@ -66,7 +78,6 @@ boolean Adafruit_MPR121::begin(uint8_t i2caddr) {
 //  writeRegister(MPR121_LOWLIMIT, 50);
   // enable all electrodes
   writeRegister(MPR121_ECR, 0x8F);  // start with first 5 bits of baseline tracking
-
   return true;
 }
 

--- a/Adafruit_MPR121.cpp
+++ b/Adafruit_MPR121.cpp
@@ -85,23 +85,12 @@ boolean Adafruit_MPR121::initMPR121(){
 }
 
 /*
-* This method is used to set the global debounce timeout for all channels.
-* Debounce is used to avoid double processing of a single touch.
-*
-* Setting the global debounce will ovveride debounce timeout set for a specific channel. 
+* This method is used to set the global debounce timeout for all channels based on time.
+* Note: this is not the chip-internal debounce! You might want to use setInternalDebounce()!
+* Debounce is used to avoid double processing of a single touch. 
 */
 void Adafruit_MPR121::setDebounce(uint16_t debounce) {
-  for (int i = 0; i < 11; i++) {
-    setDebounce(debounce, i);
-  }
-}
-
-/*
-* This method is used to set the debounce timeout for a specific channel.
-* Debounce is used to avoid double processing of a single touch.
-*/
-void Adafruit_MPR121::setDebounce(uint16_t debounce, uint8_t channel) {
-  _channels[channel]._debounce = debounce;
+  _debounce = debounce;
 }
 
 /*
@@ -109,30 +98,161 @@ void Adafruit_MPR121::setDebounce(uint16_t debounce, uint8_t channel) {
 * used as touch sensor or LED controller.
 * Returns true on success
 */
-boolean Adafruit_MPR121::setChannelType(uint8_t channel, uint8_t type) {
+boolean Adafruit_MPR121::setChannelType(uint8_t channelID, uint8_t type) {
   //first 4 (0-3) channels can not be set to LED mode
-  if(type == MPR121_LED && channel <= 3){
+  if(type != MPR121_SENSOR && channelID <= 3){
     return false;
   }
-  _channels[channel]._type = type;
+  
+  if(type >= 3){
+    //unknown type
+    return false;
+  }
+  _channels[channelID]._type = type;
+  
+  
   
   //set GPIO enabled (remember: sensor register have higher priority!)
   writeRegister(MPR121_GPIOEN, 0xFF);
   writeRegister(MPR121_GPIODIR, 0xFF);      // 0x76 is GPIO Dir
   
-  //apply config for each channel
-  for (uint8_t i = 0; i < 11; i++) {
-    Channel channel = _channels[i];
-    if(channel._type == MPR121_SENSOR){
-      //disable LED
-      //set as sensor
-    } else {
-      //enable LED
-      //disable sensor
+  //apply config for the channel
+  Channel channel = _channels[channelID];
     
+  //get current status of GPIO enabled register
+  uint8_t gpioEnabled = readRegister8(MPR121_GPIOEN);
+    
+  if(channel._type == MPR121_SENSOR){
+      
+    //disable GPIO
+    gpioEnabled ^= (-0 ^ gpioEnabled) & (1 << (channelID-4));
+    writeRegister(MPR121_GPIOEN,gpioEnabled);
+  } else {      
+    //enable GPIO
+    gpioEnabled ^= (-1 ^ gpioEnabled) & (1 << (channelID-4));
+    writeRegister(MPR121_GPIOEN,gpioEnabled);
+      
+    //set direction
+    uint8_t direction = readRegister8(MPR121_GPIODIR);
+    if(channel._type == MPR121_GPIO_OUT){
+      direction ^= (-1 ^ direction) & (1 << (channelID-4));
+    }else if(channel._type == MPR121_GPIO_IN){
+      direction ^= (-0 ^ direction) & (1 << (channelID-4));
+    }
+    writeRegister(MPR121_GPIODIR,direction);
+  }
+  
+  //enable / disable electrodes in ECR register @ 0x5E
+  int maxElectrodeID = 0;
+  for (uint8_t i=0; i<12; i++) {
+    if (_channels[i]._type == MPR121_SENSOR){
+      maxElectrodeID = i;
+    }else if( (i-1) > maxElectrodeID){
+      //ok, something is wrong -> all electrodes must be at the lower channels
+      //mixing is not possible! Seet datasheet for ECR register description
+      //lower GPIO pins will not work!
     }
   }
+  
+  //see datasheet: enables electrodes 0 - channelID for touch
+  writeRegister(MPR121_ECR,maxElectrodeID);
+  
   writeRegister(MPR121_GPIOCLR, 0xFF);    // GPIO Data Clear
+}
+
+/*
+* This method can be used to enable internal pullup resistor on a specific channel.
+* The channel must be set as GPIO_IN.
+* returns true on success, false otherwise
+*/
+boolean Adafruit_MPR121::enablePullUp(uint8_t channelID){
+  if(_channels[channelID]._type != MPR121_GPIO_IN){
+    return false;
+  }
+  //get control register
+  uint8_t ctrl0 = readRegister8(MPR121_GPIOCTL0);
+  uint8_t ctrl1 = readRegister8(MPR121_GPIOCTL1);
+  
+  //pull enabled: ctrl0 = 1; ctrl1 = 1
+  ctrl0 ^= (-1 ^ ctrl0) & (1 << (channelID-4));
+  ctrl1 ^= (-1 ^ ctrl1) & (1 << (channelID-4));
+  
+  //write back to chip
+  writeRegister(MPR121_GPIOCTL0, ctrl0);
+  writeRegister(MPR121_GPIOCTL1, ctrl1);
+  
+  //TODO clear all?
+  //writeRegister(MPR121_GPIOCLR, 0xFF);
+  
+  return true;
+}
+
+/*
+* This method can be used to enable internal pulldown resistor on a specific channel.
+* The channel must be set as GPIO_IN.
+* returns true on success, false otherwise
+*/
+boolean Adafruit_MPR121::enablePullDown(uint8_t channelID){
+  if(_channels[channelID]._type != MPR121_GPIO_IN){
+    return false;
+  }
+  //get control register
+  uint8_t ctrl0 = readRegister8(MPR121_GPIOCTL0);
+  uint8_t ctrl1 = readRegister8(MPR121_GPIOCTL1);
+  
+  //pull enabled: ctrl0 = 1; ctrl1 = 0
+  ctrl0 ^= (-1 ^ ctrl0) & (1 << (channelID-4));
+  ctrl1 &= ~(1 << (channelID-4));
+  
+  //write back to chip
+  writeRegister(MPR121_GPIOCTL0, ctrl0);
+  writeRegister(MPR121_GPIOCTL1, ctrl1);
+  
+  //TODO clear all?
+  //writeRegister(MPR121_GPIOCLR, 0xFF);
+  
+  return true;  
+} 
+
+/*
+* returns the GPIO status of the specific channel;
+* channel 0 -  3 always return false -> sensor only
+* channel 4 - 11:
+    MPR121_SENSOR   -> return false
+*   MPR121_GPIO_IN  -> read from chip and returns status
+*   MPR121_GPIO_OUT -> get status from channel if LED if enabled
+*/
+boolean Adafruit_MPR121::getGPIOStatus(uint8_t channelID){
+    if(channelID <= 3 || _channels[channelID]._type == MPR121_SENSOR){
+      return false;
+    }else if(_channels[channelID]._type == MPR121_GPIO_OUT){
+      return _channels[channelID]._gpioHigh;
+    }else{
+      // MPR121_GPIO_IN -> read current status from chip
+      uint8_t status = readRegister8(MPR121_GPIODATA);
+      _channels[channelID]._gpioHigh = (status >> (channelID-4)) & 1;
+      return _channels[channelID]._gpioHigh;
+    }
+}
+
+/*
+* This function is used to enabled/disable (set high/low) the GPIO port on a specific channel.
+* If the channel is configured as MPR121_SENSOR this method is ignored.
+*/
+void Adafruit_MPR121::setGPIOEnabled(uint8_t channelID, boolean enable){
+  if(_channels[channelID]._type == MPR121_SENSOR){
+    Serial.println("return -> SENSOR");
+    return;
+  }
+  
+  uint8_t status = readRegister8(MPR121_GPIOSET);
+  if(enable){   
+    status ^= (-1 ^ status) & (1 << (channelID-4));
+    writeRegister(MPR121_GPIOSET,status);  
+  }else{
+    status ^= (-1 ^ status) & (1 << (channelID-4)); //set n.th bit to 0
+    writeRegister(MPR121_GPIOCLR,status);
+  }
 }
 
 
@@ -147,8 +267,8 @@ void Adafruit_MPR121::setThresholds(uint8_t touch, uint8_t release) {
   }
 }
 
-void Adafruit_MPR121::useIRQ(){
-  _useIRQ = true;
+void Adafruit_MPR121::useIRQ(boolean value){
+  _useIRQ = value;
 }
 
 void Adafruit_MPR121::fireIRQ(){
@@ -170,31 +290,52 @@ uint16_t  Adafruit_MPR121::baselineData(uint8_t t) {
 * Checks the touch status for a single channel including debounce
 */
 boolean Adafruit_MPR121::touched(uint8_t channel){
-  //if channel is used as LED it is never touched
-  if(_channels[channel]._type == MPR121_LED) {
+  //if channel is used as MPR121_GPIO_OUT it is never touched
+  if(_channels[channel]._type == MPR121_GPIO_OUT) {
+    //Serial.println("MPR121: channel-type=GPIO_OUT -> touched false");
+    return false;
+  }
+  
+  //if IRQ is used -> check irq status first
+  if(_useIRQ && !_interrupted){
+    //Serial.println("MPR121: irq=true , !interrupted");
     return false;
   }
   
   // check debounce
-  if((_channels[channel]._lastTouch + _channels[channel]._debounce) < millis()) {
+  if((_channels[channel]._lastTouch + _debounce) > millis()) {
     return false;
   }
   
   // check touched
-  if(touched() & _BV(channel)){
-    //reset debounce
-    _channels[channel]._lastTouch = millis();
-    return true;
+  uint16_t touched = this->touched();
+  for (uint8_t i=0; i<12; i++){
+    if (touched & _BV(channel)){
+      //reset debounce
+      _channels[channel]._lastTouch = millis();
+      
+      //set touch state
+      _channels[channel]._touched = true;
+      
+      //reset interrupt
+      _interrupted = false;
+    }else{
+      //not touched//set touch state
+      _channels[channel]._touched = false;
+    }
   }
-  return false;
+  return _channels[channel]._touched;
 }
 
 uint16_t  Adafruit_MPR121::touched(void) {
   uint16_t result = 0;
-  //if interrupt / IRQ is used then return IRQ status
+  //if interrupt is used then return IRQ status
   if(_useIRQ){
     result = _interrupted ? 1 : 0;
   }else{ 
+    //check global debounce
+    //TODO
+    
     //else read status from MPR121 registers
     result = readRegister16(MPR121_TOUCHSTATUS_L) & 0x0FFF;
   }

--- a/Adafruit_MPR121.h
+++ b/Adafruit_MPR121.h
@@ -68,6 +68,9 @@
 
 #define MPR121_SOFTRESET 0x80
 
+#define MPR121_SENSOR 0
+#define MPR121_LED 1
+
 //.. thru to 0x1C/0x1D
 class Adafruit_MPR121 {
  public:
@@ -77,20 +80,30 @@ class Adafruit_MPR121 {
   boolean begin(uint8_t i2caddr = MPR121_I2CADDR_DEFAULT);
   boolean begin(uint8_t i2caddr, uint8_t sdaPin, uint8_t sclPin);
 
-  uint16_t filteredData(uint8_t t);
+  uint16_t  filteredData(uint8_t t);
   uint16_t  baselineData(uint8_t t);
 
-  uint8_t readRegister8(uint8_t reg);
-  uint16_t readRegister16(uint8_t reg);
-  void writeRegister(uint8_t reg, uint8_t value);
-  uint16_t touched(void);
+  uint8_t   readRegister8(uint8_t reg);
+  uint16_t  readRegister16(uint8_t reg);
+  void      writeRegister(uint8_t reg, uint8_t value);
+  uint16_t  touched(void);
+  boolean   touched(uint8_t channel);
   // Add deprecated attribute so that the compiler shows a warning
   __attribute__((deprecated)) void setThreshholds(uint8_t touch, uint8_t release);
-  void setThresholds(uint8_t touch, uint8_t release);
+  void    setThresholds(uint8_t touch, uint8_t release);
+  void    setDebounce(uint16_t debounce);
+  void    setDebounce(uint16_t debounce, uint8_t channel);
+  boolean    setChannelType(uint8_t channel, uint8_t type);
 
  private:
+  struct Channel {
+    uint16_t _debounce = 0;
+    long _lastTouch = 0;
+    uint8_t _type = MPR121_SENSOR;
+  };
   int8_t _i2caddr;
   boolean initMPR121(void);
+  Channel _channels[12];;
 };
 
 #endif // ADAFRUIT_MPR121_H

--- a/Adafruit_MPR121.h
+++ b/Adafruit_MPR121.h
@@ -45,31 +45,36 @@
 #define MPR121_FDLT         0x35
 
 #define MPR121_TOUCHTH_0    0x41
-#define MPR121_RELEASETH_0    0x42
-#define MPR121_DEBOUNCE 0x5B
-#define MPR121_CONFIG1 0x5C
-#define MPR121_CONFIG2 0x5D
+#define MPR121_RELEASETH_0  0x42
+#define MPR121_DEBOUNCE     0x5B
+#define MPR121_CONFIG1      0x5C
+#define MPR121_CONFIG2      0x5D
 #define MPR121_CHARGECURR_0 0x5F
 #define MPR121_CHARGETIME_1 0x6C
-#define MPR121_ECR 0x5E
-#define MPR121_AUTOCONFIG0 0x7B
-#define MPR121_AUTOCONFIG1 0x7C
-#define MPR121_UPLIMIT   0x7D
-#define MPR121_LOWLIMIT  0x7E
+#define MPR121_ECR          0x5E
+#define MPR121_AUTOCONFIG0  0x7B
+#define MPR121_AUTOCONFIG1  0x7C
+#define MPR121_UPLIMIT      0x7D
+#define MPR121_LOWLIMIT     0x7E
 #define MPR121_TARGETLIMIT  0x7F
 
-#define MPR121_GPIODIR  0x76
-#define MPR121_GPIOEN  0x77
-#define MPR121_GPIOSET  0x78
-#define MPR121_GPIOCLR  0x79
-#define MPR121_GPIOTOGGLE  0x7A
+#define MPR121_GPIODIR      0x76
+#define MPR121_GPIOEN       0x77
+#define MPR121_GPIOSET      0x78
+#define MPR121_GPIOCLR      0x79
+#define MPR121_GPIOTOGGLE   0x7A
+#define MPR121_GPIOCTL0     0x73
+#define MPR121_GPIOCTL1     0x74
+#define MPR121_GPIODATA     0x75
+
 
 
 
 #define MPR121_SOFTRESET 0x80
 
 #define MPR121_SENSOR 0
-#define MPR121_LED 1
+#define MPR121_GPIO_IN 1
+#define MPR121_GPIO_OUT 2
 
 //.. thru to 0x1C/0x1D
 class Adafruit_MPR121 {
@@ -91,24 +96,36 @@ class Adafruit_MPR121 {
   // Add deprecated attribute so that the compiler shows a warning
   __attribute__((deprecated)) void setThreshholds(uint8_t touch, uint8_t release);
   void    setThresholds(uint8_t touch, uint8_t release);
+  
+  //debounce functions
   void    setDebounce(uint16_t debounce);
-  void    setDebounce(uint16_t debounce, uint8_t channel);
+  
+  //LED controller functions
   boolean    setChannelType(uint8_t channel, uint8_t type);
-  void      useIRQ();
+  boolean    getGPIOStatus(uint8_t channel);
+  void       setGPIOEnabled(uint8_t channel, boolean status);
+  boolean    enablePullUp(uint8_t channel);
+  boolean    enablePullDown(uint8_t channel); 
+  
+  //IRQ / Interrupt functions
+  void      useIRQ(boolean value);
   void      fireIRQ();
 
 
  private:
   struct Channel {
-    uint16_t _debounce = 0;
-    long _lastTouch = 0;
-    uint8_t _type = MPR121_SENSOR;
+    long      _lastTouch = 0;
+    uint8_t   _type = MPR121_SENSOR;
+    boolean   _gpioHigh = false;
+    boolean   _touched = false;
   };
 
     Channel _channels[12];
     int8_t    _i2caddr;
+    uint16_t  _debounce = 0;
+    
+    //irq / interrupt variables
     boolean   _useIRQ;
-    int8_t    _irqPin;
     boolean   _interrupted;
     
     boolean   initMPR121(void);

--- a/Adafruit_MPR121.h
+++ b/Adafruit_MPR121.h
@@ -75,6 +75,7 @@ class Adafruit_MPR121 {
   Adafruit_MPR121(void);
 
   boolean begin(uint8_t i2caddr = MPR121_I2CADDR_DEFAULT);
+  boolean begin(uint8_t i2caddr = MPR121_I2CADDR_DEFAULT, uint8_t sdaPin = SDA, uint8_t sclPin = SCL);
 
   uint16_t filteredData(uint8_t t);
   uint16_t  baselineData(uint8_t t);
@@ -89,6 +90,7 @@ class Adafruit_MPR121 {
 
  private:
   int8_t _i2caddr;
+  boolean initMPR121();
 };
 
 #endif // ADAFRUIT_MPR121_H

--- a/Adafruit_MPR121.h
+++ b/Adafruit_MPR121.h
@@ -67,9 +67,6 @@
 #define MPR121_GPIOCTL1     0x74
 #define MPR121_GPIODATA     0x75
 
-
-
-
 #define MPR121_SOFTRESET 0x80
 
 #define MPR121_SENSOR 0
@@ -83,7 +80,9 @@ class Adafruit_MPR121 {
   Adafruit_MPR121(void);
 
   boolean begin(uint8_t i2caddr = MPR121_I2CADDR_DEFAULT);
+  #if defined(ESP8266)
   boolean begin(uint8_t i2caddr, uint8_t sdaPin, uint8_t sclPin);
+  #endif
 
   uint16_t  filteredData(uint8_t t);
   uint16_t  baselineData(uint8_t t);
@@ -102,19 +101,13 @@ class Adafruit_MPR121 {
   
   //LED controller functions
   boolean    setChannelType(uint8_t channel, uint8_t type);
+  uint8_t    getChannelType(uint8_t channel);
   boolean    getGPIOStatus(uint8_t channel);
   void       setGPIOEnabled(uint8_t channel, boolean status);
-  boolean    enablePullUp(uint8_t channel);
-  boolean    enablePullDown(uint8_t channel); 
-  
-  //IRQ / Interrupt functions
-  void      useIRQ(boolean value);
-  void      fireIRQ();
 
 
  private:
   struct Channel {
-    long      _lastTouch = 0;
     uint8_t   _type = MPR121_SENSOR;
     boolean   _gpioHigh = false;
     boolean   _touched = false;
@@ -123,10 +116,7 @@ class Adafruit_MPR121 {
     Channel _channels[12];
     int8_t    _i2caddr;
     uint16_t  _debounce = 0;
-    
-    //irq / interrupt variables
-    boolean   _useIRQ;
-    boolean   _interrupted;
+    long      _lastTouch = 0;
     
     boolean   initMPR121(void);
 };

--- a/Adafruit_MPR121.h
+++ b/Adafruit_MPR121.h
@@ -94,7 +94,8 @@ class Adafruit_MPR121 {
   void    setDebounce(uint16_t debounce);
   void    setDebounce(uint16_t debounce, uint8_t channel);
   boolean    setChannelType(uint8_t channel, uint8_t type);
-  void      registerIRQ(uint8_t irqPin);
+  void      useIRQ();
+  void      fireIRQ();
 
 
  private:
@@ -103,15 +104,13 @@ class Adafruit_MPR121 {
     long _lastTouch = 0;
     uint8_t _type = MPR121_SENSOR;
   };
-  int8_t _i2caddr;
-  boolean initMPR121(void);
-  Channel _channels[12];
+
+    Channel _channels[12];
     int8_t    _i2caddr;
     boolean   _useIRQ;
     int8_t    _irqPin;
     boolean   _interrupted;
     
-    void      fireIRQ(void);
     boolean   initMPR121(void);
 };
 

--- a/Adafruit_MPR121.h
+++ b/Adafruit_MPR121.h
@@ -75,7 +75,7 @@ class Adafruit_MPR121 {
   Adafruit_MPR121(void);
 
   boolean begin(uint8_t i2caddr = MPR121_I2CADDR_DEFAULT);
-  boolean begin(uint8_t i2caddr = MPR121_I2CADDR_DEFAULT, uint8_t sdaPin = SDA, uint8_t sclPin = SCL);
+  boolean begin(uint8_t i2caddr, uint8_t sdaPin, uint8_t sclPin);
 
   uint16_t filteredData(uint8_t t);
   uint16_t  baselineData(uint8_t t);
@@ -90,7 +90,7 @@ class Adafruit_MPR121 {
 
  private:
   int8_t _i2caddr;
-  boolean initMPR121();
+  boolean initMPR121(void);
 };
 
 #endif // ADAFRUIT_MPR121_H

--- a/examples/Arduino-GPIO/Arduino-GPIO.ino
+++ b/examples/Arduino-GPIO/Arduino-GPIO.ino
@@ -1,0 +1,125 @@
+/*
+ * This example shows how to use MPR121 library on Arduino with hardware I2C support
+ * using GPIO functions and touch buttons with debounce.
+ * 
+ * Hardware:
+ *    Use an Arduino (Nano) with I2C support and a MPR121 breakout board.
+ *    If your Arduino doesn´t support hardware I2C you can use the software I2C version for ESP8266 in the other example!
+ *    Connect Arduino to 5V VCC and MPR121 to 3.3V VCC output of the Arduino and GND (or use a voltage regulator such as LM117 or LF33CV).
+ *    Connect SDA/SCAL lines from MPR121 board to pins 18/19 on Arduino (see note below!)
+ *    
+ *    If your breakout board already has pullup-resistors for SDA/SCL lines no extra resistors are needed
+ *    otherwise you may need to hook SDA/SCL lines with 4.7k resistors to ground for a stable communication.
+ *    To show the touch control feature a LED will be used. Hook up the LED and resistors on pins as defined below.
+ *    
+ *    - Connect a touchpad on MPR121 pin 0 (channel 0); normal cable will do
+ *    - Connect MPR121 pin 8 (channel 8) with resistor to VCC
+ *    - Connect a LED with resistor on MPR121 pin 11 (Channel 11) and to ground
+ *    
+ * Note:
+ *    If using an 5V compliant Arduino note that there are two different logic level in your circuit now:
+ *    5V for the Arduino and 3.3V for the MPR121.
+ *    This means for the SDA/SCL lines you would need a bidirectional logic-level-shifter in between the Arduino and the MPR121.
+ *    I would recommend to use a LLS in between for stable communication on to prevent your MPR121 from burning.
+ *    Please check your data-sheet carfully which voltage is accepted for I2C communication on MPR and Arduino!
+ *    Same might be for the IRQ pin!
+ *    (For me it works without a LLV on an Arduino Nano but no guarantee!)
+ */
+
+#include <Adafruit_MPR121.h>
+#include <Wire.h>
+
+//define pins used
+#define IRQ_PIN 3
+
+//touch button on MPR121 channel 0
+#define PIN_MPR_SENSOR 0
+
+//GPIO in on channel 10
+#define PIN_MPR_GPIO_IN 10
+
+//GPIO out on MPR121 Channel 11
+#define PIN_MPR_GPIO_OUT 11
+
+static boolean debug = true;
+
+Adafruit_MPR121 cap = Adafruit_MPR121();
+
+
+void setup() {
+  //start-Serial for output
+  Serial.begin(9600);
+  Serial.println(F("Starting MPR121-Arduino example...."));
+
+  //show us which SDA/SCL pins are used
+  if(debug){
+    Serial.print("Using I2C Pins: SDA=");
+    Serial.print(SDA);
+    Serial.print(", SCL=");
+    Serial.println(SCL);
+  }
+  
+  //init MPR121 touch sensor using default SDA/SCL pins for arduino
+  if (!cap.begin(0x5A)) {
+    Serial.println(F("MPR121 touch sensor not found!"));
+    while (true) {
+      delay(100);
+      Serial.print(".");
+    }
+  }
+  Serial.println("MPR121 found");
+  
+  //set button debounce
+  cap.setDebounce(100);
+
+  //configure MPR121 channels
+  cap.setChannelType(PIN_MPR_GPIO_OUT,MPR121_GPIO_OUT); //channel 11 is GPIO out (LED)
+  cap.setChannelType(PIN_MPR_GPIO_IN,MPR121_GPIO_IN); //channel 10 is GPIO in
+  
+  Serial.println(F("MPR121 touch sensor initialized..."));
+ 
+
+  Serial.println(F("Init complete..."));
+  Serial.println(F("------------------------------"));
+}
+
+
+void loop() {
+   
+  //check if touch button was pressed
+  boolean isButtonPressed = cap.touched(PIN_MPR_SENSOR);
+
+  if(isButtonPressed & debug){
+    Serial.print("Buttons: ");
+    for (uint8_t channel = 0; channel <= 11; channel++) {
+      //only print if the channel is of type SENSOR
+      if(cap.getChannelType(channel) != MPR121_SENSOR){
+        continue;
+      }
+      Serial.print(channel);
+      Serial.print("=");
+      if(cap.touched(channel)){
+        Serial.print("Y");
+      }else {
+        Serial.print("N");
+      }
+      Serial.print(" | ");
+    }
+    Serial.println("");
+  }
+
+  //if button is pressed -> light up LED through MPR121
+  cap.setGPIOEnabled(PIN_MPR_GPIO_OUT,isButtonPressed);
+
+  //check if GPIO is enabled
+  boolean gpioStatus = cap.getGPIOStatus(PIN_MPR_GPIO_IN);
+  
+  //if false -> error (must always be high as connected to VCC!)
+  if(!gpioStatus){
+    Serial.println("ERROR GPIO IS NOT HIGH! cables?");
+    delay(100);
+  }
+
+}
+
+

--- a/examples/ESP8266-GPIO/ESP8266-GPIO.ino
+++ b/examples/ESP8266-GPIO/ESP8266-GPIO.ino
@@ -1,0 +1,133 @@
+/*
+ * This example shows how to use MPR121 library on ESP8266 with hardware I2C support
+ * using GPIO functions and touch buttons with debounce.
+ * 
+ * Hardware:
+ *    Use an ESP8266 and a MPR121 breakout board.
+ *    Connect ESP and MPR121 to 3.3V VCC and GND (e.g. use a voltage regulator such as LM117 or LF33CV).
+ *    Connect SDA/SCAL lines from MPR121 board to pins 4/5 on ESP (see note below!)
+ *    
+ *    If your breakout board already has pullup-resistors for SDA/SCL lines no extra resistors are needed
+ *    otherwise you may need to hook SDA/SCL lines with 4.7k resistors to ground for a stable communication.
+ *    To show the touch control feature a LED will be used. Hook up the LED and resistors on pins as defined below.
+ *    
+ *    - Connect a touchpad on MPR121 pin 0 (channel 0); normal cable will do
+ *    - Connect MPR121 pin 8 (channel 8) with resistor to VCC
+ *    - Connect a LED with resistor on MPR121 pin 11 (Channel 11) and to ground
+ *    
+ * Notes:
+ *    Because all your components are running on 3.3V you dont need a logic-level converter.
+ *    (If you use an arduino on 5V you might need a LLC).
+ *    
+ *    It seems there is an error in underlying libraries that prevent fromm choosing random pins for SDA/SCL.
+ *    I only get I2C running on my ESp when pins 4/5 are used for SDA/SCL (like on Ardunino)!
+ */
+
+#include <Wire.h>
+#include <Adafruit_MPR121.h>
+
+//define pins used
+#define PIN_SCL 5
+#define PIN_SDA 4 
+
+//touch button on MPR121 channel 0
+#define PIN_MPR_SENSOR 0
+
+//GPIO in on channel 10
+#define PIN_MPR_GPIO_IN 10
+
+//GPIO out on MPR121 Channel 11
+#define PIN_MPR_GPIO_OUT 11
+
+static boolean debug = true;
+
+Adafruit_MPR121 cap = Adafruit_MPR121();
+
+//some hacks for the adafruit-lib at 160Mhz to work correctly with neopixels
+#if defined(ESP8266)
+  extern void preloop_update_frequency();
+#endif
+
+void setup() {
+  //some hacks for the adafruit-lib at 160Mhz to work correctly with neopixels
+  #if defined(ESP8266)
+     preloop_update_frequency();
+  #endif
+
+  
+  //start-Serial for output
+  Serial.begin(9600);
+  Serial.println(F("Starting MPR121-Arduino example...."));
+
+  //show us which SDA/SCL pins are used
+  if(debug){
+    Serial.print("Using I2C Pins: SDA=");
+    Serial.print(PIN_SDA);
+    Serial.print(", SCL=");
+    Serial.println(PIN_SCL);
+  }
+  
+  //init MPR121 touch sensor using default SDA/SCL pins for arduino
+  if (!cap.begin(0x5A,PIN_SDA,PIN_SCL)) {
+    Serial.println(F("MPR121 touch sensor not found!"));
+    while (true) {
+      delay(100);
+      Serial.print(".");
+    }
+  }
+  Serial.println("MPR121 found");
+  
+  //set button debounce
+  cap.setDebounce(100);
+
+  //configure MPR121 channels
+  cap.setChannelType(PIN_MPR_GPIO_OUT,MPR121_GPIO_OUT); //channel 11 is GPIO out (LED)
+  cap.setChannelType(PIN_MPR_GPIO_IN,MPR121_GPIO_IN); //channel 10 is GPIO in
+  
+  Serial.println(F("MPR121 touch sensor initialized..."));
+ 
+
+  Serial.println(F("Init complete..."));
+  Serial.println(F("------------------------------"));
+}
+
+
+void loop() {
+   
+  //check if touch button was pressed
+  boolean isButtonPressed = cap.touched(PIN_MPR_SENSOR);
+
+  if(isButtonPressed & debug){
+    Serial.print("Buttons: ");
+    for (uint8_t channel = 0; channel <= 11; channel++) {
+      //only print if the channel is of type SENSOR
+      if(cap.getChannelType(channel) != MPR121_SENSOR){
+        continue;
+      }
+      Serial.print(channel);
+      Serial.print("=");
+      if(cap.touched(channel)){
+        Serial.print("Y");
+      }else {
+        Serial.print("N");
+      }
+      Serial.print(" | ");
+    }
+    Serial.println("");
+  }
+
+  //if button is pressed -> light up LED through MPR121
+  cap.setGPIOEnabled(PIN_MPR_GPIO_OUT,isButtonPressed);
+
+  //check if GPIO is enabled
+  boolean gpioStatus = cap.getGPIOStatus(PIN_MPR_GPIO_IN);
+  
+  //if false -> error (must always be high as connected to VCC!)
+  if(!gpioStatus){
+    Serial.println("ERROR GPIO IS NOT HIGH! cables?");
+    delay(100);
+  }
+
+}
+
+

--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,9 @@
+name=Adafruit MPR121
+version=1.0.0
+author=Adafruit <info@adafruit.com>
+maintainer=Adafruit <info@adafruit.com>
+sentence=Arduino library for the MPR121-based capacitive sensors in the Adafruit shop.
+paragraph=Designed specifically to work with the MPR121 Breakout in the Adafruit shop.
+category=Sensors
+url=https://github.com/adafruit/Adafruit_MPR121_Library
+architectures=*


### PR DESCRIPTION
Hello,

just added the following modifications to the library.
- support for external IRQ in functions:
  - setIRQ(bool);
  - fireIRQ();
- support for channel types: GPIO (IN/OUT), SENSOR
  - enablePullUp();
  - enablePullDown();
  - setChannelType(i, type)
  - getGPGIOStatus(i);
  - setGPIOEnabled(i, bool);
- global timed debounce for sensors (internal debounce to be added)
- added comments & documentation
- includes previous pull request for ESp8266 support (#5)

Tested on plain ESP8266 12-E, ESP8266 7

... and yes; some parts might look like java. feel free to change.
