### PR TITLE
Issue #21 - Fix readRegister8/16() functions to work with the arduino…

### DIFF
--- a/Adafruit_MPR121.cpp
+++ b/Adafruit_MPR121.cpp
@@ -199,10 +199,7 @@ uint16_t Adafruit_MPR121::touched(void) {
  *  @returns    the 8 bit value that was read.
  */
 uint8_t Adafruit_MPR121::readRegister8(uint8_t reg) {
-  _wire->beginTransmission(_i2caddr);
-  _wire->write(reg);
-  _wire->endTransmission(false);
-  _wire->requestFrom(_i2caddr, 1);
+  _wire.requestFrom(_i2caddr, 1, reg, 1, 0);
   if (_wire->available() < 1)
     return 0;
   return (_wire->read());
@@ -214,10 +211,7 @@ uint8_t Adafruit_MPR121::readRegister8(uint8_t reg) {
  *  @returns    the 16 bit value that was read.
  */
 uint16_t Adafruit_MPR121::readRegister16(uint8_t reg) {
-  _wire->beginTransmission(_i2caddr);
-  _wire->write(reg);
-  _wire->endTransmission(false);
-  _wire->requestFrom(_i2caddr, 2);
+  _wire.requestFrom(_i2caddr, 2, reg, 1, 0);
   if (_wire->available() < 2)
     return 0;
   uint16_t v = _wire->read();

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Atmega32u4 @ 16MHz |      X       |             |            |
 Atmega32u4 @ 8MHz  |      X       |             |            | 
 ESP8266            |      X       |             |            | 
 Atmega2560 @ 16MHz |      X       |             |            | 
-ATSAM3X8E          |             |      X       |            | 
+ATSAM3X8E          |      X       |             |            | 
 ATSAM21D           |      X       |             |            | 
 ATtiny85 @ 16MHz   |             |             |     X       | 
 ATtiny85 @ 8MHz    |             |             |     X       | 


### PR DESCRIPTION
… due (SAM3x8e)

https://github.com/adafruit/Adafruit_MPR121/issues/21
- looks like Wire library replaced "Wire" object with "_wire" since the time the issue was created