### PR TITLE
Update Adafruit_MPR121.cpp

### DIFF
--- a/Adafruit_MPR121.cpp
+++ b/Adafruit_MPR121.cpp
@@ -241,7 +241,7 @@ void Adafruit_MPR121::writeRegister(uint8_t reg, uint8_t value) {
   if (stop_required) {
     _wire->beginTransmission(_i2caddr);
     _wire->write(MPR121_ECR);
-    _wire->write(0x00); // clear this register to set stop modus
+    _wire->write((byte)0x00); // clear this register to set stop modus
     _wire->endTransmission();
   }
 


### PR DESCRIPTION
Fixes Issue #29

Compiler error "call of overloaded 'write(int)' is ambiguous" is fixed by casting 0x00 to a `byte`. 

The issue relates to the overloads available in the Wire library.

First time submitting a PR to you guys so let me know if you require more detail!