### PR TITLE
Bug Fix with setThreshold function Adafruit_MPR121.cpp

### DIFF
--- a/Adafruit_MPR121.cpp
+++ b/Adafruit_MPR121.cpp
@@ -140,15 +140,11 @@ void Adafruit_MPR121::setThreshholds(uint8_t touch, uint8_t release) {
  *              the release threshold from 0 to 255.
  */
 void Adafruit_MPR121::setThresholds(uint8_t touch, uint8_t release) {
-  // first stop sensor to make changes
-  writeRegister(MPR121_ECR, 0x00);
   // set all thresholds (the same)
   for (uint8_t i = 0; i < 12; i++) {
     writeRegister(MPR121_TOUCHTH_0 + 2 * i, touch);
     writeRegister(MPR121_RELEASETH_0 + 2 * i, release);
   }
-  // turn the sensor on again
-  writeRegister(MPR121_ECR, 0x8F);
 }
 
 /*!


### PR DESCRIPTION
 No need to modify the register ECR in this function because the stop is already done in function "writeRegister()".

The following line : writeRegister(MPR121_ECR, 0x8F);
cause an issue because is restart the MPR121 with a constant value : 0x8F
if the user modified previously, and then set the treshold, user setting are lost.

mathis.raemy@gmail.com for more informations