### PR TITLE
Updates and fixes related to autoconfig change.

### DIFF
--- a/Adafruit_MPR121.cpp
+++ b/Adafruit_MPR121.cpp
@@ -57,14 +57,10 @@ bool Adafruit_MPR121::begin(uint8_t i2caddr, TwoWire *theWire,
   }
   i2c_dev = new Adafruit_I2CDevice(i2caddr, theWire);
 
-  Serial.println("Adafruit_I2CDevice setup..");
   if (!i2c_dev->begin()) {
-    Serial.println("i2c_dev begin failed..");
     return false;
   }
-  Serial.println("done.");
 
-  Serial.println("send soft reset..");
   // soft reset
   writeRegister(MPR121_SOFTRESET, 0x63);
   delay(1);
@@ -75,13 +71,10 @@ bool Adafruit_MPR121::begin(uint8_t i2caddr, TwoWire *theWire,
 
   writeRegister(MPR121_ECR, 0x0);
 
-  Serial.print("read: MPR121_CONFIG2 ");
   uint8_t c = readRegister8(MPR121_CONFIG2);
-  Serial.println(c, HEX);
   if (c != 0x24)
     return false;
 
-  Serial.println("write Configuration to sensor ...");
   setThresholds(touchThreshold, releaseThreshold);
   writeRegister(MPR121_MHDR, 0x01);
   writeRegister(MPR121_NHDR, 0x01);

--- a/examples/MPR121test/MPR121test.ino
+++ b/examples/MPR121test/MPR121test.ino
@@ -1,17 +1,17 @@
 /*********************************************************
 This is a library for the MPR121 12-channel Capacitive touch sensor
 
-Designed specifically to work with the MPR121 Breakout in the Adafruit shop 
+Designed specifically to work with the MPR121 Breakout in the Adafruit shop
   ----> https://www.adafruit.com/products/
 
-These sensors use I2C communicate, at least 2 pins are required 
+These sensors use I2C communicate, at least 2 pins are required
 to interface
 
-Adafruit invests time and resources providing this open source code, 
-please support Adafruit and open-source hardware by purchasing 
+Adafruit invests time and resources providing this open source code,
+please support Adafruit and open-source hardware by purchasing
 products from Adafruit!
 
-Written by Limor Fried/Ladyada for Adafruit Industries.  
+Written by Limor Fried/Ladyada for Adafruit Industries.
 BSD license, all text above must be included in any redistribution
 **********************************************************/
 
@@ -19,7 +19,7 @@ BSD license, all text above must be included in any redistribution
 #include "Adafruit_MPR121.h"
 
 #ifndef _BV
-#define _BV(bit) (1 << (bit)) 
+#define _BV(bit) (1 << (bit))
 #endif
 
 // You can have up to 4 on one i2c bus but one is enough for testing!
@@ -36,9 +36,9 @@ void setup() {
   while (!Serial) { // needed to keep leonardo/micro from starting too fast!
     delay(10);
   }
-  
-  Serial.println("Adafruit MPR121 Capacitive Touch sensor test"); 
-  
+
+  Serial.println("Adafruit MPR121 Capacitive Touch sensor test");
+
   // Default address is 0x5A, if tied to 3.3V its 0x5B
   // If tied to SDA its 0x5C and if SCL then 0x5D
   if (!cap.begin(0x5A)) {
@@ -46,12 +46,19 @@ void setup() {
     while (1);
   }
   Serial.println("MPR121 found!");
+
+  // This is generally recommended since it seems to work well for most setups.
+  // Can remove if wanting to manually configure touch channels (CDC and CDT).
+  Serial.println("Running auto configuration.");
+  cap.setAutoconfig(true);
+
+  Serial.println("Initialization complete.");
 }
 
 void loop() {
   // Get the currently touched pads
   currtouched = cap.touched();
-  
+
   for (uint8_t i=0; i<12; i++) {
     // it if *is* touched and *wasnt* touched before, alert!
     if ((currtouched & _BV(i)) && !(lasttouched & _BV(i)) ) {
@@ -68,7 +75,7 @@ void loop() {
 
   // comment out this line for detailed data from the sensor!
   return;
-  
+
   // debugging info, what
   Serial.print("\t\t\t\t\t\t\t\t\t\t\t\t\t 0x"); Serial.println(cap.touched(), HEX);
   Serial.print("Filt: ");
@@ -81,7 +88,7 @@ void loop() {
     Serial.print(cap.baselineData(i)); Serial.print("\t");
   }
   Serial.println();
-  
+
   // put a delay so it isn't overwhelming
   delay(100);
 }


### PR DESCRIPTION
This is for #49.

* The various `Serial.print`s that were included with PR #43 have been removed. (clean up)
* The `MPR121test` example has been updated to add a call to `setAutoconfig()` which restores the original behavior prior to #43. (patch fix)

**NOTE** - #43 made a breaking change by refactoring auto config to a function and **not** calling it by default. The original code had auto config running hardwired in `begin()`, so was always done. The `1.2.0` release should have been a major number change. In order to restore the original behavior, the `autoconfig` parameter could be changed to `true`:
https://github.com/adafruit/Adafruit_MPR121/blob/ca5deb53ff53e9c21951dd85f068e0ddf1ad492e/Adafruit_MPR121.h#L92
but this is probably worth a separate issue/discussion.